### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
@@ -25,6 +27,9 @@ jobs:
   release:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/ombr/sf-formula/security/code-scanning/2](https://github.com/ombr/sf-formula/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for each job. For the `test` job, only `contents: read` is needed, as it involves running tests and uploading coverage reports. For the `release` job, additional permissions such as `contents: write` and `packages: write` are required to perform a semantic release and publish packages.

The `permissions` block will be added at the job level to ensure that each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
